### PR TITLE
Changes the function names of the main api

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,8 +1,9 @@
 import {
+  Config,
   load,
   generate,
+  generateSync,
   types,
-  Config,
 } from '../src';
 import { configDefaults } from '../src/bin/config';
 
@@ -52,6 +53,26 @@ describe('module', () => {
       };
 
       const response: any = await generate(schema);
+      expect(typeof response.name).toBe('string');
+    });
+  });
+
+  describe('.generateSync()', () => {
+    it('generates fake data from a file', () => {
+      const response: any = generateSync('fixtures/schema.fixture.json');
+      expect(typeof response.data.name).toBe('string');
+    });
+
+    it('generates fake data from a schema object', () => {
+      const schema = {
+        title: 'Schema Object',
+        required: [ 'name' ],
+        properties: {
+          name: { type: 'string' }
+        }
+      };
+
+      const response: any = generateSync(schema);
       expect(typeof response.name).toBe('string');
     })
   });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -17,7 +17,7 @@ describe('module', () => {
     Config.set(configDefaults);
   });
 
-  describe('.loadSchema()', () => {
+  describe('.load()', () => {
     it('loads from a file path', () => {
       const schema: any = load('fixtures/schema.fixture.json');
       expect(schema).toMatchObject({
@@ -38,7 +38,7 @@ describe('module', () => {
 
   describe('.generate()', () => {
     it('generates fake data from a file', async () => {
-      const response: any = generate(fixtures/schema.fixture.json');
+      const response: any = await generate('fixtures/schema.fixture.json');
       expect(typeof response.data.name).toBe('string');
     });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,13 +1,13 @@
 import {
-  loadSchema,
-  generateResponseFromSchema,
+  load,
+  generate,
   types,
 } from '../src';
 
 describe('module', () => {
-  describe('.loadSchema()', () => {
+  describe('.load()', () => {
     it('loads from a file path', () => {
-      const schema: any = loadSchema(__dirname + '/fixtures/schema.fixture.json');
+      const schema: any = load(__dirname + '/fixtures/schema.fixture.json');
       expect(schema).toMatchObject({
         title: 'my schema',
         required: ['data'],
@@ -24,9 +24,9 @@ describe('module', () => {
     });
   });
 
-  describe('.generateResponseFromSchema()', () => {
+  describe('.generate()', () => {
     it('generates fake data from a file', async () => {
-      const response: any = await generateResponseFromSchema(__dirname + '/fixtures/schema.fixture.json');
+      const response: any = await generate(__dirname + '/fixtures/schema.fixture.json');
       expect(typeof response.data.name).toBe('string');
     });
 
@@ -39,7 +39,7 @@ describe('module', () => {
         }
       };
 
-      const response: any = await generateResponseFromSchema(schema);
+      const response: any = await generate(schema);
       expect(typeof response.name).toBe('string');
     })
   });

--- a/__tests__/lib/config.test.ts
+++ b/__tests__/lib/config.test.ts
@@ -1,4 +1,4 @@
-import { loadSchema, Config } from '../../src';
+import { load, Config } from '../../src';
 import { configDefaults } from '../../src/bin/config';
 
 describe('config', () => {
@@ -31,7 +31,7 @@ describe('config', () => {
       }
     });
 
-    const contract = loadSchema('sub/nested.contract');
+    const contract = load('sub/nested.contract');
     expect(contract).toEqual({
       title: 'Nested Contract',
       required: ['name'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,14 @@ import { join } from 'path';
 import * as types from './types';
 import { resolve } from 'json-schema-faker';
 
-export const loadSchema = (schemaPath: string): any => {
+export const load = (schemaPath: string): any => {
   const schema = require(schemaPath);
   return schema;
 };
 
-export const generateResponseFromSchema = (schemaPath: string | {}): Promise<any> => {
+export const generate = (schemaPath: string | {}): Promise<any> => {
   const schema = (typeof schemaPath === 'string')
-    ? loadSchema(schemaPath)
+    ? load(schemaPath)
     : schemaPath;
   return resolve(schema);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,25 @@
-import { join } from 'path';
+import { join, resolve } from 'path';
 import * as types from './types';
 import * as jsf from 'json-schema-faker';
 import Config from './bin/config';
-import { resolve } from 'path';
+
+const getFilePath = (schemaPath: string): string => {
+  const regex = /^(.+)\//;
+  const match = schemaPath.match(regex);
+  const aliasKey = match && match[1] || '';
+  const relativePath = schemaPath.replace(regex, '');
+  const pathAlias = Config.aliases[aliasKey] || Config.contractsRoot;
+  const absolutePath = resolve(Config.appRoot, pathAlias, relativePath);
+  return absolutePath;
+};
+
+const getSchema = (schemaPath: string | {}): Promise<any> | {} => {
+  const schema = (typeof schemaPath === 'string')
+    ? load(schemaPath)
+    : schemaPath;
+
+  return schema;
+};
 
 export const load = (schemaPath: string): any => {
   const absolutePath = getFilePath(schemaPath);
@@ -10,26 +27,13 @@ export const load = (schemaPath: string): any => {
   return schema;
 };
 
-const getFilePath = (schemaPath: string): string => {
-  const regex = /^(.+)\//;
-  const aliasKey = schemaPath.match(regex)[1];
-  const relativePath = schemaPath.replace(regex, '');
-  const pathAlias = Config.aliases[aliasKey] || Config.contractsRoot;
-  const absolutePath = resolve(Config.appRoot, pathAlias, relativePath);
-  return absolutePath;
-};
-
 export const generate = (schemaPath: string | {}): Promise<any> => {
-  const schema = (typeof schemaPath === 'string')
-    ? load(schemaPath)
-    : schemaPath;
+  const schema = getSchema(schemaPath);
   return jsf.resolve(schema);
 };
 
-export const generateSync = (schemaPath: string | {}): any => {
-  const schema = (typeof schemaPath === 'string')
-    ? load(schemaPath)
-    : schemaPath;
+export const generateSync = (schemaPath: string | {}): {} => {
+  const schema = getSchema(schemaPath);
   return jsf(schema);
 };
 


### PR DESCRIPTION
- `.generateResponseFromSchema() => .generate()`
- `.loadSchema() => .load()`